### PR TITLE
add 'Extended title' from Phoca Cart Categories to dynamic content source

### DIFF
--- a/modules/phoca/src/PhocacartCategoryType.php
+++ b/modules/phoca/src/PhocacartCategoryType.php
@@ -6,6 +6,7 @@ class PhocacartCategoryType
   public static $fieldsToKeep = [
     'id',
     'title',
+    'title_long',
     'description',
     'image',
   ];


### PR DESCRIPTION
I'm new to Phoca Cart, but the 'Extended titel' is worth to add as dynamic content source field.