### PR TITLE
add special_parameters as field in PhocacartCategoryType.php

### DIFF
--- a/modules/phoca/src/PhocacartCategoryType.php
+++ b/modules/phoca/src/PhocacartCategoryType.php
@@ -8,6 +8,7 @@ class PhocacartCategoryType
     'title',
     'description',
     'image',
+	'special_parameter'  
   ];
 
   public static $fieldsToAdd = [


### PR DESCRIPTION
Refers to the special_parameters field, which is fetched from the database to link to the category in Yootheme as Dynamic Content. Use special_parameters as Dynamic Field in Yootheme to create the link